### PR TITLE
Fix for MapProxy zoom calculations.

### DIFF
--- a/header.inc
+++ b/header.inc
@@ -63,10 +63,13 @@
     VALIDATION
       "MAP_RESOLUTION"               "^[0-9]{1,3}$"
       "DPI"                          "^[0-9]{1,3}$"
-      "default_MAP_RESOLUTION"       "72"
-      "default_DPI"                  "72"
+      "default_MAP_RESOLUTION"       "91"
+      "default_DPI"                  "91"
     END
   END
+
+  RESOLUTION                         91
+  DEFRESOLUTION                      91
 
   PROJECTION
     "init=epsg:28992"

--- a/private/header.inc
+++ b/private/header.inc
@@ -63,10 +63,13 @@
     VALIDATION
       "MAP_RESOLUTION"               "^[0-9]{1,3}$"
       "DPI"                          "^[0-9]{1,3}$"
-      "default_MAP_RESOLUTION"       "72"
-      "default_DPI"                  "72"
+      "default_MAP_RESOLUTION"       "91"
+      "default_DPI"                  "91"
     END
   END
+
+  RESOLUTION                         91
+  DEFRESOLUTION                      91
 
   PROJECTION
     "init=epsg:28992"


### PR DESCRIPTION
MapProxy adheres to OGC spec: 1px ~ 0.28 mm. Thus, 25.4/0.28 ~= 91dpi.