### PR TITLE
update zoom level kbk10, colors in BGT, 10 and 50

### DIFF
--- a/bgt.map
+++ b/bgt.map
@@ -103,18 +103,7 @@ MAP
 			END
 		END
 		CLASS
-			EXPRESSION      {transitie,open verharding}
-			MAXSCALEDENOM   5000
-			STYLE
-				COLOR         "#F4F6F6"
-				OUTLINECOLOR  "#F4F6F6"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {gesloten verharding,half verhard,perron}
+			EXPRESSION      {gesloten verharding,half verhard,perron,transitie,open verharding}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#FFFFFF"
@@ -203,17 +192,6 @@ MAP
 			"wms_group_title"      "vlakken"
 		END
 		CLASS
-			EXPRESSION      ("[bgt_functie]" IN "parkeervlak")
-			MAXSCALEDENOM   5000
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
 			EXPRESSION      ("[bgt_functie]" IN "berm" AND "[bgt_fysiekvoorkomen]"  IN "gesloten verharding,half verhard,open verharding,transitie")
 			MAXSCALEDENOM   5000
 			STYLE
@@ -254,17 +232,10 @@ MAP
 			"wms_group_title"      "vlakken"
 		END
 		CLASS
-			EXPRESSION      ("[bgt_functie]" IN "parkeervlak")
-			MAXSCALEDENOM   5000
-			STYLE
-				COLOR         "#FFFFFF"
-			END
-		END
-		CLASS
 			EXPRESSION      ("[bgt_functie]" IN "berm" AND "[bgt_fysiekvoorkomen]"  IN "gesloten verharding,half verhard,open verharding,transitie")
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#F6F3F4"
 			END
 		END
 		CLASS
@@ -295,12 +266,12 @@ MAP
 				"wms_group_title"      "vlakken"
 			END
 			CLASS
-				EXPRESSION      {fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,baan voor vliegverkeer}
+				EXPRESSION      {fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,parkeervlak,transitie,baan voor vliegverkeer}
 				MAXSCALEDENOM   5000
 				STYLE
 					COLOR         "#C9C7C2"
 					OUTLINECOLOR  "#C9C7C2"
-					WIDTH         1.8
+					WIDTH         1
 					LINECAP       BUTT
 					LINEJOIN      MITER
 				END
@@ -325,7 +296,7 @@ MAP
 			"wms_group_title"      "vlakken"
 		END
 	    CLASS
-			EXPRESSION      {fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie}
+			EXPRESSION      {fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,parkeervlak,transitie}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#FFFFFF"
@@ -392,7 +363,7 @@ MAP
 			EXPRESSION      {ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf,verkeerseiland}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#f7f3f5"
 			END
 		END
 	END
@@ -442,6 +413,289 @@ MAP
 				WIDTH         0.5
 				LINECAP       BUTT
 				LINEJOIN      MITER
+			END
+		END
+	END
+
+#==============================================================================
+# Gebouw 0
+	LAYER
+		NAME                    gebouw_vlak0
+		GROUP                   vlakken
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.gebouw_vlak0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    POLYGON
+		CLASSITEM               bgt_type
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "gebouw_vlak0"
+			"wms_group_title"      "vlakken"
+		END
+		CLASS
+		# overig bouwwerk
+			EXPRESSION      {bassin,bezinkbak,lage trafo,niet-bgt,open loods,opslagtank,overkapping,transitie,windturbine}
+			MAXSCALEDENOM   2000
+			MINSCALEDENOM	5000
+			STYLE
+				COLOR         "#E0DED8"
+				OUTLINECOLOR  "#C9C7C2"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+		# overig bouwwerk
+			EXPRESSION      {bassin,bezinkbak,lage trafo,niet-bgt,open loods,opslagtank,overkapping,transitie,windturbine}
+			MAXSCALEDENOM   2000
+			STYLE
+				COLOR         "#E0DED8"
+				OUTLINECOLOR  "#C9C7C2"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END	
+		CLASS
+		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
+			MAXSCALEDENOM   5000
+			MINSCALEDENOM	2000
+			STYLE
+				COLOR         "#E5E3DE"
+				OUTLINECOLOR  "#C9C7C2"
+				WIDTH         0.9
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
+			MAXSCALEDENOM   2000
+			STYLE
+				COLOR         "#E5E3DE"
+				OUTLINECOLOR  "#C9C7C2"
+				WIDTH         0.9
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+	END
+
+#==============================================================================
+
+# Metro achter 0
+	LAYER
+		NAME                    metro_achter0
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_achter0"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+#==============================================================================
+# Metro voor 0
+	LAYER
+		NAME                    metro_voor0
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_voor0"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+
+#==============================================================================
+# Tram 0
+	LAYER
+		NAME                    tram0
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "tram0"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      tram
+			MAXSCALEDENOM   5000
+			STYLE
+				WIDTH         1.5
+				COLOR         "#FC7F7F"
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      tram
+			MAXSCALEDENOM   2000
+			STYLE
+				WIDTH         2
+				COLOR         "#FC7F7F"
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+	END
+
+#==============================================================================
+# Trein achter 0
+	LAYER
+		NAME                    trein_achter0
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "trein_achter0"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#9D9D9D"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#9D9D9D"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+#==============================================================================
+# Trein voor 0
+	LAYER
+		NAME                    trein_voor0
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "trein_voor0"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					8
+					8
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					8
+					8
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
 			END
 		END
 	END
@@ -502,76 +756,6 @@ MAP
 	      END
 	    END
 	END
-
-#==============================================================================
-# Gebouw 0
-	LAYER
-		NAME                    gebouw_vlak0
-		GROUP                   vlakken
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.gebouw_vlak0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    POLYGON
-		CLASSITEM               bgt_type
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouw_vlak0"
-			"wms_group_title"      "vlakken"
-		END
-		CLASS
-		# overig bouwwerk
-			EXPRESSION      {bassin,bezinkbak,lage trafo,niet-bgt,open loods,opslagtank,overkapping,transitie,windturbine}
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM	5000
-			STYLE
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-		# overig bouwwerk
-			EXPRESSION      {bassin,bezinkbak,lage trafo,niet-bgt,open loods,opslagtank,overkapping,transitie,windturbine}
-			MAXSCALEDENOM   2000
-			STYLE
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END	
-		CLASS
-		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
-			MAXSCALEDENOM   5000
-			MINSCALEDENOM	2000
-			STYLE
-				COLOR         "#EBEAE6"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
-			MAXSCALEDENOM   2000
-			STYLE
-				COLOR         "#EBEAE6"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
-
-
 
 
 #==============================================================================
@@ -644,32 +828,36 @@ MAP
 			END
 		END
 		CLASS
-			EXPRESSION      {transitie,open verharding,perron}
-			MAXSCALEDENOM   5000
-			STYLE
-				COLOR         "#F4F6F6"
-				OUTLINECOLOR  "#F4F6F6"
-			END
-		END
-		CLASS
-			EXPRESSION      {gesloten verharding,half verhard}
+			EXPRESSION      {gesloten verharding,half verhard,perron,transitie,open verharding}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#FFFFFF"
 				OUTLINECOLOR  "#FFFFFF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 		CLASS
-			EXPRESSION      {groenvoorziening,grasland overig}
+			EXPRESSION      {groenvoorziening,struiken,grasland agrarisch,grasland overig}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#DCEACF"
+				OUTLINECOLOR  "#DCEACF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 		CLASS
+			EXPRESSION      {naaldbos,fruitteelt,loofbos,bouwland,gemengd bos,moeras,boomteelt}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#DDDCDA"
+				COLOR         "#CBE0B8"
+				OUTLINECOLOR  "#CBE0B8"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 		# oever, slootkant
@@ -765,7 +953,7 @@ MAP
 			EXPRESSION      ("[bgt_functie]" IN "berm" AND "[bgt_fysiekvoorkomen]"  IN "gesloten verharding,half verhard,open verharding,transitie")
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#F6F3F4"
 			END
 		END
 		CLASS
@@ -886,7 +1074,7 @@ MAP
 			EXPRESSION      {ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf,verkeerseiland}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#f7f3f5"
 			END
 		END
 	END
@@ -951,7 +1139,7 @@ MAP
 			MAXSCALEDENOM   5000
 			MINSCALEDENOM	2000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -962,7 +1150,7 @@ MAP
 		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
 			MAXSCALEDENOM   2000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -1019,8 +1207,219 @@ MAP
 			END
 		END
 	END
+#==============================================================================
+# Metro achter 1
+	LAYER
+		NAME                    metro_achter1
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_achter1"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+#==============================================================================
+# Metro voor 1
+	LAYER
+		NAME                    metro_voor1
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_voor1"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
 
+#==============================================================================
+# Tram 1 
+	LAYER
+		NAME                    tram1
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "tram1"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      tram
+			MAXSCALEDENOM   5000
+			STYLE
+				WIDTH         1.5
+				COLOR         "#FC7F7F"
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      tram
+			MAXSCALEDENOM   2000
+			STYLE
+				WIDTH         2
+				COLOR         "#FC7F7F"
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+	END
 
+#==============================================================================
+# Trein achter 1 
+	LAYER
+		NAME                    trein_achter1
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "trein_achter1"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#9D9D9D"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#9D9D9D"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+#==============================================================================
+# Trein voor 1 
+	LAYER
+		NAME                    trein_voor1
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "trein_voor1"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					8
+					8
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					8
+					8
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
 #==============================================================================
 # Snelweg achter 1
 	LAYER
@@ -1122,23 +1521,36 @@ MAP
 			END
 		END
 		CLASS
-			EXPRESSION      {gesloten verharding,perron}
+			EXPRESSION      {gesloten verharding,half verhard,perron,transitie,open verharding}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#FFFFFF"
+				OUTLINECOLOR  "#FFFFFF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 		CLASS
-			EXPRESSION      {transitie}
+			EXPRESSION      {groenvoorziening,struiken,grasland agrarisch,grasland overig}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F4F6F6"
+				COLOR         "#DCEACF"
+				OUTLINECOLOR  "#DCEACF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 		CLASS
+			EXPRESSION      {naaldbos,fruitteelt,loofbos,bouwland,gemengd bos,moeras,boomteelt}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#DDDCDA"
+				COLOR         "#CBE0B8"
+				OUTLINECOLOR  "#CBE0B8"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 		# oever, slootkant
@@ -1233,7 +1645,7 @@ MAP
 			EXPRESSION      ("[bgt_functie]" IN "berm" AND "[bgt_fysiekvoorkomen]"  IN "gesloten verharding,half verhard,open verharding,transitie")
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#F6F3F4"
 			END
 		END
 		CLASS
@@ -1354,7 +1766,7 @@ MAP
 			EXPRESSION      {ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf,verkeerseiland}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#f7f3f5"
 			END
 		END
 	END
@@ -1419,7 +1831,7 @@ MAP
 			MAXSCALEDENOM   5000
 			MINSCALEDENOM	2000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -1430,7 +1842,7 @@ MAP
 		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
 			MAXSCALEDENOM   2000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -1476,6 +1888,180 @@ MAP
 				WIDTH         0.5
 				LINECAP       BUTT
 				LINEJOIN      MITER
+			END
+		END
+	END
+
+#==============================================================================
+# Metro achter 2
+	LAYER
+		NAME                    metro_achter2
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_achter2"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+#==============================================================================
+# Metro voor 2
+	LAYER
+		NAME                    metro_voor2
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_voor2"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+
+#==============================================================================
+# Trein achter 2 
+	LAYER
+		NAME                    trein_achter2
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "trein_achter2"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#9D9D9D"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#9D9D9D"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+#==============================================================================
+# Trein voor 2 
+	LAYER
+		NAME                    trein_voor2
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "trein_voor2"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					8
+					8
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION           trein
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					8
+					8
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
 			END
 		END
 	END
@@ -1560,10 +2146,67 @@ MAP
 			"wms_group_title"      "vlakken"
 		END
 		CLASS
-			EXPRESSION      {perron}
+			EXPRESSION      {erf,zand,onverhard,houtwal,duin,rietland}
+			MAXSCALEDENOM   5000
+			MINSCALEDENOM   2000
+			STYLE
+				COLOR         "#F9F9E7"
+				OUTLINECOLOR  "#F9F9E7"
+			END
+		END
+		CLASS
+			EXPRESSION      {erf,zand,onverhard,houtwal,duin,rietland}
+			MAXSCALEDENOM   2000
+			STYLE
+				COLOR         "#F9F9E7"
+				OUTLINECOLOR  "#C9C7C2"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      {gesloten verharding,half verhard,perron,transitie,open verharding}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#FFFFFF"
+				OUTLINECOLOR  "#FFFFFF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      {groenvoorziening,struiken,grasland agrarisch,grasland overig}
+			MAXSCALEDENOM   5000
+			STYLE
+				COLOR         "#DCEACF"
+				OUTLINECOLOR  "#DCEACF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      {naaldbos,fruitteelt,loofbos,bouwland,gemengd bos,moeras,boomteelt}
+			MAXSCALEDENOM   5000
+			STYLE
+				COLOR         "#CBE0B8"
+				OUTLINECOLOR  "#CBE0B8"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		# oever, slootkant
+		CLASS
+			MAXSCALEDENOM   5000
+			STYLE
+				COLOR         "#F9F9E7"
+				OUTLINECOLOR  "#F9F9E7"
+				WIDTH         0.1
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 	END
@@ -1677,7 +2320,7 @@ MAP
 			EXPRESSION      {ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf,verkeerseiland}
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#F2ECEE"
+				COLOR         "#f7f3f5"
 			END
 		END
 	END
@@ -1742,7 +2385,7 @@ MAP
 			MAXSCALEDENOM   5000
 			MINSCALEDENOM	2000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -1753,7 +2396,7 @@ MAP
 		# pand; gebouwinstallatie plus_type: {bordes,bunker,luifel,onbekend,schuur,toegangstrap,voedersilo}
 			MAXSCALEDENOM   2000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -1761,11 +2404,98 @@ MAP
 			END
 		END
 	END
+#==============================================================================
+# Metro achter 3
+	LAYER
+		NAME                    metro_achter3
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn3 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_achter3"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 3
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 3.5
+				OUTLINECOLOR "#FC7F7F"
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
+
+#==============================================================================
+# Metro voor 3
+	LAYER
+		NAME                    metro_voor3
+		GROUP                   lijnen
+		INCLUDE                 "connection_basiskaart.inc"
+		DATA                    "geometrie FROM bgt.spoor_lijn3 USING srid=28992 USING UNIQUE identificatie_lokaalid"
+		PROCESSING              "CLOSE_CONNECTION=DEFER"
+		TYPE                    LINE
+		CLASSITEM               bgt_functie
+		MAXSCALEDENOM           5000
+		PROJECTION
+			"init=epsg:28992"
+		END
+		METADATA
+			"wms_title"            "metro_voor2"
+			"wms_group_title"      "lijnen"
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           5000
+			STYLE
+				WIDTH 2
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+		CLASS
+			EXPRESSION      sneltram
+			MAXSCALEDENOM           2000
+			STYLE
+				WIDTH 2.5
+				OUTLINECOLOR "#FFFFFF"
+				PATTERN
+					7
+					7
+				END
+				LINECAP BUTT
+				LINEJOIN MITER
+			END
+		END
+	END
 
 #==============================================================================
 # Snelweg achter 3
 	LAYER
-			NAME                    snelweg_achter_3
+			NAME                    snelweg_achter3
 			GROUP                   vlakken
 			INCLUDE                 "connection_basiskaart.inc"
 			DATA                    "geometrie FROM bgt.wegdeel_vlak3 USING srid=28992 USING UNIQUE identificatie_lokaalid"
@@ -1795,7 +2525,7 @@ MAP
 #==============================================================================
 # Snelweg voor 3
 	LAYER
-		NAME                    snelweg_voor_3
+		NAME                    snelweg_voor3
 		GROUP                   vlakken
 		INCLUDE                 "connection_basiskaart.inc"
 		DATA                    "geometrie FROM bgt.wegdeel_vlak3 USING srid=28992 USING UNIQUE identificatie_lokaalid"
@@ -1844,10 +2574,67 @@ MAP
 			"wms_group_title"      "vlakken"
 		END
 		CLASS
-			EXPRESSION      {perron}
+			EXPRESSION      {erf,zand,onverhard,houtwal,duin,rietland}
+			MAXSCALEDENOM   5000
+			MINSCALEDENOM   2000
+			STYLE
+				COLOR         "#F9F9E7"
+				OUTLINECOLOR  "#F9F9E7"
+			END
+		END
+		CLASS
+			EXPRESSION      {erf,zand,onverhard,houtwal,duin,rietland}
+			MAXSCALEDENOM   2000
+			STYLE
+				COLOR         "#F9F9E7"
+				OUTLINECOLOR  "#C9C7C2"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      {gesloten verharding,half verhard,perron,transitie,open verharding}
 			MAXSCALEDENOM   5000
 			STYLE
 				COLOR         "#FFFFFF"
+				OUTLINECOLOR  "#FFFFFF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      {groenvoorziening,struiken,grasland agrarisch,grasland overig}
+			MAXSCALEDENOM   5000
+			STYLE
+				COLOR         "#DCEACF"
+				OUTLINECOLOR  "#DCEACF"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		CLASS
+			EXPRESSION      {naaldbos,fruitteelt,loofbos,bouwland,gemengd bos,moeras,boomteelt}
+			MAXSCALEDENOM   5000
+			STYLE
+				COLOR         "#CBE0B8"
+				OUTLINECOLOR  "#CBE0B8"
+				WIDTH         0.5
+				LINECAP       BUTT
+				LINEJOIN      MITER
+			END
+		END
+		# oever, slootkant
+		CLASS
+			MAXSCALEDENOM   5000
+			STYLE
+				COLOR         "#F9F9E7"
+				OUTLINECOLOR  "#F9F9E7"
+				WIDTH         0.1
+				LINECAP       BUTT
+				LINEJOIN      MITER
 			END
 		END
 	END
@@ -1898,7 +2685,7 @@ MAP
 		CLASS
 			MAXSCALEDENOM   5000
 			STYLE
-				COLOR         "#EBEAE6"
+				COLOR         "#E5E3DE"
 				OUTLINECOLOR  "#C9C7C2"
 				WIDTH         0.9
 				LINECAP       BUTT
@@ -1915,7 +2702,6 @@ MAP
 #==============================================================================
 ## HOOGTELIGGING -2
 #==============================================================================
-
 
 # Metro -2
 	LAYER
@@ -1938,7 +2724,6 @@ MAP
 			EXPRESSION      sneltram
 			MAXSCALEDENOM   5000
 			STYLE
-				OPACITY 50
 				WIDTH 1.5
 				OUTLINECOLOR "#FC7F7F"
 				PATTERN
@@ -1953,7 +2738,6 @@ MAP
 			EXPRESSION      sneltram
 			MAXSCALEDENOM   2000
 			STYLE
-				OPACITY 50
 				WIDTH 2
 				OUTLINECOLOR "#FC7F7F"
 				PATTERN
@@ -2019,8 +2803,6 @@ MAP
 #==============================================================================
 ## HOOGTELIGGING -1
 #==============================================================================
-
-
 # Metro achter -1
 	LAYER
 		NAME                    metro_achter_1
@@ -2252,708 +3034,6 @@ MAP
 		END
 	END
 
-#==============================================================================
-## HOOGTELIGGING 0
-#==============================================================================
-
-# Metro achter 0
-	LAYER
-		NAME                    metro_achter0
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter0"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-#==============================================================================
-# Metro voor 0
-	LAYER
-		NAME                    metro_voor0
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor0"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#==============================================================================
-# Tram 0
-	LAYER
-		NAME                    tram0
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "tram0"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      tram
-			MAXSCALEDENOM   5000
-			STYLE
-				WIDTH         1.5
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      tram
-			MAXSCALEDENOM   2000
-			STYLE
-				WIDTH         2
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
-
-#==============================================================================
-# Trein achter 0
-	LAYER
-		NAME                    trein_achter0
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter0"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-#==============================================================================
-# Trein voor 0
-	LAYER
-		NAME                    trein_voor0
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn0 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor0"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#==============================================================================
-## HOOGTELIGGING 1
-#==============================================================================
-
-
-# Metro achter 1
-	LAYER
-		NAME                    metro_achter1
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter1"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-#==============================================================================
-# Metro voor 1
-	LAYER
-		NAME                    metro_voor1
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor1"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#==============================================================================
-# Tram 1 
-	LAYER
-		NAME                    tram1
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "tram1"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      tram
-			MAXSCALEDENOM   5000
-			STYLE
-				WIDTH         1.5
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      tram
-			MAXSCALEDENOM   2000
-			STYLE
-				WIDTH         2
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
-
-#==============================================================================
-# Trein achter 1 
-	LAYER
-		NAME                    trein_achter1
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter1"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-#==============================================================================
-# Trein voor 1 
-	LAYER
-		NAME                    trein_voor1
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn1 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor1"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#==============================================================================
-## HOOGTELIGGING 2
-#==============================================================================
-
-# Metro achter 2
-	LAYER
-		NAME                    metro_achter2
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter2"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-#==============================================================================
-# Metro voor 2
-	LAYER
-		NAME                    metro_voor2
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor2"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#==============================================================================
-# Trein achter 2 
-	LAYER
-		NAME                    trein_achter2
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter2"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-#==============================================================================
-# Trein voor 2 
-	LAYER
-		NAME                    trein_voor2
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn2 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor2"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION           trein
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#=============================================================================
-## HOOGTELIGGING 3
-#=============================================================================
-
-# Metro achter 3
-	LAYER
-		NAME                    metro_achter3
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn3 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter3"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-#==============================================================================
-# Metro voor 3
-	LAYER
-		NAME                    metro_voor3
-		GROUP                   lijnen
-		INCLUDE                 "connection_basiskaart.inc"
-		DATA                    "geometrie FROM bgt.spoor_lijn3 USING srid=28992 USING UNIQUE identificatie_lokaalid"
-		PROCESSING              "CLOSE_CONNECTION=DEFER"
-		TYPE                    LINE
-		CLASSITEM               bgt_functie
-		MAXSCALEDENOM           5000
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor2"
-			"wms_group_title"      "lijnen"
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           5000
-			STYLE
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			EXPRESSION      sneltram
-			MAXSCALEDENOM           2000
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
 
 #==============================================================================
 # TEKSTEN 

--- a/kbk10.map
+++ b/kbk10.map
@@ -79,7 +79,7 @@ MAP
     NAME                    WDL_breed_water
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_breed_water\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -89,7 +89,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#95c6d5"
       END
@@ -102,7 +102,7 @@ MAP
     NAME                    WDL_haven
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_haven\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE POLYGON
@@ -112,7 +112,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#95c6d5"
       END
@@ -125,7 +125,7 @@ MAP
     NAME                    TRN_aanlegsteiger
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_aanlegsteiger\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -135,7 +135,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 1
         OUTLINECOLOR "#acacac"
@@ -152,7 +152,7 @@ MAP
     NAME                    TRN_basaltblokken_steenglooiing
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_basaltblokken_steenglooiing\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -162,7 +162,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#f6f6f4"
       END
@@ -175,7 +175,7 @@ MAP
     NAME                    TRN_grasland
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_grasland\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -185,7 +185,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#dceacf"
       END
@@ -198,7 +198,7 @@ MAP
     NAME                    TRN_akkerland
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_akkerland\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -208,7 +208,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#dceacf"
       END
@@ -221,7 +221,7 @@ MAP
     NAME                    TRN_overig
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_overig\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -231,7 +231,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#f2ecee"
       END
@@ -244,7 +244,7 @@ MAP
     NAME                    TRN_bedrijfsterrein
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bedrijfsterrein\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -254,7 +254,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#f6f6f4"
       END
@@ -267,7 +267,7 @@ MAP
     NAME                    TRN_openbaar_groen
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_openbaar_groen\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -277,7 +277,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#f9f9e7"
       END
@@ -290,7 +290,7 @@ MAP
     NAME                    TRN_zand
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_zand\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -300,7 +300,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#fbf0de"
       END
@@ -313,7 +313,7 @@ MAP
     NAME                    WGL_startbaan_landingsbaan
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_startbaan_landingsbaan\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -323,7 +323,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#dddcda"
       END
@@ -336,7 +336,7 @@ MAP
     NAME                    TRN_spoorbaanlichaam
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_spoorbaanlichaam\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -346,7 +346,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#dddcda"
       END
@@ -359,7 +359,7 @@ MAP
     NAME                    TRN_bos-loofbos
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-loofbos\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -369,7 +369,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#cbe0b8"
       END
@@ -382,7 +382,7 @@ MAP
     NAME                    TRN_bos-naaldbos
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-naaldbos\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -392,7 +392,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#cbe0b8"
       END
@@ -405,7 +405,7 @@ MAP
     NAME                    TRN_bos-gemengd_bos
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-gemengd_bos\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -415,7 +415,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#cbe0b8"
       END
@@ -428,7 +428,7 @@ MAP
     NAME                    TRN_bos-griend
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-griend\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -438,7 +438,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#cbe0b8"
       END
@@ -451,7 +451,7 @@ MAP
     NAME                    TRN_boomgaard
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_boomgaard\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -461,7 +461,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#d4e5c4"
       END
@@ -474,7 +474,7 @@ MAP
     NAME                    TRN_boomkwekerij
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_boomkwekerij\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -484,7 +484,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#d4e5c4"
       END
@@ -497,7 +497,7 @@ MAP
     NAME                    TRN_dodenakker
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_dodenakker\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -507,7 +507,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#d4e5c4"
       END
@@ -520,7 +520,7 @@ MAP
     NAME                    TRN_dodenakker_met_bos
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_dodenakker_met_bos\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -530,7 +530,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#d4e5c4"
       END
@@ -543,7 +543,7 @@ MAP
     NAME                    TRN_fruitkwekerij
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_fruitkwekerij\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -553,7 +553,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#d4e5c4"
       END
@@ -566,7 +566,7 @@ MAP
     NAME                    GBW_overdekt
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -575,7 +575,7 @@ MAP
     END
     CLASS
       STYLE
-        COLOR "#ebeae6"
+        COLOR "#e5e3de"
       END
     END
   END
@@ -587,7 +587,7 @@ MAP
     NAME                    GBW_gebouw
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_gebouw\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -597,9 +597,9 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
-        COLOR "#ebeae6"
+        COLOR "#e5e3de"
       END
       STYLE
         WIDTH 0.9
@@ -616,7 +616,7 @@ MAP
     NAME                    GBW_hoogbouw
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_hoogbouw\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -626,7 +626,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#e6e5e0"
       END
@@ -645,7 +645,7 @@ MAP
     NAME                    GBW_kas_warenhuis
     GROUP                   "vlakken"
     MAXSCALEDENOM           10000
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_kas_warenhuis\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -655,7 +655,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#e3dbd3"
       END
@@ -668,7 +668,7 @@ MAP
     NAME                    TRN_binnentuin-case
     GROUP                   "vlakken"
     MAXSCALEDENOM           8000
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_binnentuin\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -678,7 +678,7 @@ MAP
     CLASS
       # Zoom{=16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 1
         OUTLINECOLOR "#c9c7c2"
@@ -694,7 +694,7 @@ MAP
     NAME                    TRN_binnentuin-fill
     GROUP                   "vlakken"
     MAXSCALEDENOM 8000
-    MINSCALEDENOM 4000
+    MINSCALEDENOM 5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_binnentuin\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE POLYGON
@@ -704,7 +704,7 @@ MAP
     CLASS
       # Zoom{=16}
       MAXSCALEDENOM 10000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#f9f9e7"
       END
@@ -717,7 +717,7 @@ MAP
     NAME                    WDL_waterbassin
     GROUP                   "vlakken"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_waterbassin\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -727,7 +727,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         COLOR "#95c6d5"
       END
@@ -740,7 +740,7 @@ MAP
     NAME                    WDL_smal_water_3_tot_6m
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_smal_water_3_tot_6m\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -750,7 +750,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         COLOR "#95c6d5"
@@ -766,7 +766,7 @@ MAP
     NAME                    WDL_smal_water_tot_3m
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_smal_water_tot_3m\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -776,7 +776,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 1
         COLOR "#95c6d5"
@@ -792,7 +792,7 @@ MAP
     NAME                    KRT_tunnelcontour
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"KRT_tunnelcontour\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -818,7 +818,7 @@ MAP
     NAME                    IRT_aanlegsteiger_smal
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"IRT_aanlegsteiger_smal\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -828,7 +828,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 1
         OUTLINECOLOR "#acacac80"
@@ -844,7 +844,7 @@ MAP
     NAME                    WGL_smalle_weg-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_smalle_weg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -854,7 +854,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         COLOR "#c9c7c2"
@@ -870,7 +870,7 @@ MAP
     NAME                    WGL_smalle_weg-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_smalle_weg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -880,7 +880,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 12500
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         COLOR "#ffffff"
@@ -896,7 +896,7 @@ MAP
     NAME                    SBL_metro_overdekt_case
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -922,7 +922,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 7999
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 4
         INITIALGAP 2
@@ -943,7 +943,7 @@ MAP
     NAME                    SBL_metro_overdekt_line
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -968,7 +968,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 7999
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -988,7 +988,7 @@ MAP
     NAME                    SBL_tram_overdekt
     GROUP                   "lijnen"
     MAXSCALEDENOM           8000
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_tram_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -998,7 +998,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 1
         PATTERN
@@ -1018,7 +1018,7 @@ MAP
     NAME                    SBL_trein_overdekt_1sp-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-	MINSCALEDENOM           4000
+	MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_overdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1041,7 +1041,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         OUTLINECOLOR "#9d9d9d"
@@ -1061,7 +1061,7 @@ MAP
     NAME                    SBL_trein_overdekt_nsp-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-	MINSCALEDENOM           4000
+	MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_overdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1084,7 +1084,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         OUTLINECOLOR "#9d9d9d"
@@ -1126,7 +1126,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -1169,7 +1169,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -1189,7 +1189,7 @@ MAP
     NAME                    SBL_metro_nietoverdekt_1sp_case
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1210,7 +1210,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         OUTLINECOLOR "#fc7f7f"
@@ -1226,7 +1226,7 @@ MAP
     NAME                    SBL_metro_nietoverdekt_1sp_dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1251,7 +1251,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -1271,7 +1271,7 @@ MAP
     NAME                    SBL_metro_nietoverdekt_nsp_case
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1292,7 +1292,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         OUTLINECOLOR "#fc7f7f"
@@ -1308,7 +1308,7 @@ MAP
     NAME                    SBL_metro_nietoverdekt_nsp_dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1333,7 +1333,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -1353,7 +1353,7 @@ MAP
     NAME                    SBL_tram_nietoverdekt
     GROUP                   "lijnen"
     MAXSCALEDENOM           8000
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_tram_nietoverdekt\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1363,7 +1363,7 @@ MAP
     CLASS
       # Zoom{16}
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 1
         COLOR "#fc7f7f"
@@ -1379,7 +1379,7 @@ MAP
     NAME                    SBL_trein_ongeelektrificeerd-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-	MINSCALEDENOM           4000
+	MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_ongeelektrificeerd\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1398,7 +1398,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         COLOR "#9d9d9d"
@@ -1414,7 +1414,7 @@ MAP
     NAME                    SBL_trein_ongeelektrificeerd-dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-	MINSCALEDENOM           4000
+	MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_ongeelektrificeerd\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1437,7 +1437,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         PATTERN
@@ -1457,7 +1457,7 @@ MAP
     NAME                    SBL_trein_nietoverdekt_1sp-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1476,7 +1476,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         OUTLINECOLOR "#9d9d9d"
@@ -1492,7 +1492,7 @@ MAP
     NAME                    SBL_trein_nietoverdekt_nsp-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1511,7 +1511,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 3
         OUTLINECOLOR "#9d9d9d"
@@ -1527,7 +1527,7 @@ MAP
     NAME                    SBL_trein_nietoverdekt_1sp-dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-	MINSCALEDENOM           4000
+	MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1550,7 +1550,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 12500
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -1571,7 +1571,7 @@ MAP
     NAME                    SBL_trein_nietoverdekt_nsp-dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-	MINSCALEDENOM           4000
+	MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1594,7 +1594,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 12500
-	  MINSCALEDENOM 4000
+	  MINSCALEDENOM 5000
       STYLE
         WIDTH 2
         OUTLINECOLOR "#ffffff"
@@ -1614,7 +1614,7 @@ MAP
     NAME                    WGL_autosnelweg_lijn-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_hartlijn\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1637,7 +1637,7 @@ MAP
       # Zoom{16}
       EXPRESSION              ("[TYPEWEG]" eq "autosnelweg")
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 6
         COLOR "#fa0000"
@@ -1653,7 +1653,7 @@ MAP
     NAME                    WGL_autosnelweg_lijn-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           12500
-    MINSCALEDENOM           4000
+    MINSCALEDENOM           5000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_hartlijn\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1676,7 +1676,7 @@ MAP
       # Zoom{16}
       EXPRESSION              ("[TYPEWEG]" eq "autosnelweg")
       MAXSCALEDENOM 8000
-      MINSCALEDENOM 4000
+      MINSCALEDENOM 5000
       STYLE
         WIDTH 4
         COLOR "#fefafa"

--- a/kbk10_light.xml
+++ b/kbk10_light.xml
@@ -5,7 +5,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -21,7 +21,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -37,7 +37,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -57,7 +57,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -73,7 +73,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -89,7 +89,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -105,7 +105,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -121,7 +121,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -137,7 +137,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -153,7 +153,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -169,7 +169,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -185,7 +185,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -201,7 +201,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -217,7 +217,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -233,7 +233,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -249,7 +249,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -265,7 +265,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -281,7 +281,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -297,7 +297,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -313,7 +313,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -329,7 +329,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -345,7 +345,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -361,7 +361,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -383,7 +383,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -405,7 +405,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -421,7 +421,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Stroke>
@@ -438,7 +438,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>10000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -454,7 +454,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -470,7 +470,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -487,7 +487,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -504,7 +504,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -522,7 +522,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -539,7 +539,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -556,7 +556,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -583,7 +583,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -610,7 +610,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -627,7 +627,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -654,7 +654,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -681,7 +681,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -708,7 +708,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -735,7 +735,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -762,7 +762,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -789,7 +789,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -816,7 +816,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -843,7 +843,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -860,7 +860,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -887,7 +887,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -914,7 +914,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -941,7 +941,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -968,7 +968,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -995,7 +995,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -1022,7 +1022,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -1061,7 +1061,7 @@
               <ogc:Literal>autosnelweg</ogc:Literal>
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -1100,7 +1100,7 @@
               <ogc:Literal>autosnelweg</ogc:Literal>
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>

--- a/kbk10_zw.xml
+++ b/kbk10_zw.xml
@@ -5,7 +5,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -21,7 +21,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -37,7 +37,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -57,7 +57,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -73,7 +73,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -89,7 +89,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -105,7 +105,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -121,7 +121,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -137,7 +137,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -153,7 +153,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -169,7 +169,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -185,7 +185,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -201,7 +201,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -217,7 +217,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -233,7 +233,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -249,7 +249,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -265,7 +265,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -281,7 +281,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -297,7 +297,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -313,7 +313,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -329,7 +329,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -345,7 +345,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -361,7 +361,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -383,7 +383,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -405,7 +405,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -421,7 +421,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Stroke>
@@ -438,7 +438,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>10000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -454,7 +454,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -470,7 +470,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -487,7 +487,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -504,7 +504,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -522,7 +522,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -539,7 +539,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -556,7 +556,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -583,7 +583,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -610,7 +610,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -627,7 +627,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -654,7 +654,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -681,7 +681,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -708,7 +708,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -735,7 +735,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -762,7 +762,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -789,7 +789,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -816,7 +816,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -843,7 +843,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -860,7 +860,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -887,7 +887,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -914,7 +914,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -941,7 +941,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -968,7 +968,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -995,7 +995,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -1022,7 +1022,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>12500</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -1061,7 +1061,7 @@
               <ogc:Literal>autosnelweg</ogc:Literal>
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -1100,7 +1100,7 @@
               <ogc:Literal>autosnelweg</ogc:Literal>
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
-          <MinScaleDenominator>4000</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>

--- a/kbk50.map
+++ b/kbk50.map
@@ -176,13 +176,13 @@ MAP
       MAXSCALEDENOM 400000
       MINSCALEDENOM 12500
       STYLE
-        COLOR "#ebeae6"
+        COLOR "#e5e3de"
       END
       STYLE
       MAXSCALEDENOM 50000
       MINSCALEDENOM 12500
         WIDTH 0.7
-        OUTLINECOLOR "#ebeae6"
+        OUTLINECOLOR "#e5e3de"
         LINECAP BUTT
         LINEJOIN MITER
       END
@@ -868,7 +868,7 @@ MAP
       MINSCALEDENOM 25000
       STYLE
         WIDTH 1.75
-        COLOR "#ebeae6"
+        COLOR "#c9c7c2"
         LINECAP BUTT
         LINEJOIN MITER
       END


### PR DESCRIPTION
- Gebouwen donkerder, voetpaden lichter.
- Transitie wit. 
- Parkeer vlakken bij wegdeel getrokken. 
- sporen op hoogte niveau behalve ondergronds.  (nog niet in de xml) 